### PR TITLE
Add `contents: read` to workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
       name: release
     permissions:
       id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v3


### PR DESCRIPTION
When the default permissions have been changed, we need to add the permission manually

Fixes #1