### PR TITLE
Fix for Node 20 deprecation warnings & Python Update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,8 @@ jobs:
         uses: actions/checkout@v6
       - name: Install uv
         uses: astral-sh/setup-uv@v7
-      - name: Install Python 3.13
-        run: uv python install 3.13
+      - name: Install Python 3.14
+        run: uv python install 3.14
       - name: Build
         run: uv build
       # Check that basic features work and we didn't miss to include crucial files

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,9 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
       - name: Install Python 3.13
         run: uv python install 3.13
       - name: Build


### PR DESCRIPTION
Running this as it was triggers Node 20 deprecation warnings becase it is EOL for Github actions.

Not sure if the warnings have teeth but updating the components removes the warnings during use.  

Also updated Python version to 3.14 in other commit. 